### PR TITLE
TSWoW functions for OnHealEarly, OnDamage, OnDamageMelee, OnUpdate(allpetstats), AddThreatAllAssist (not working)

### DIFF
--- a/tswow-core/Private/TSEventsLua.cpp
+++ b/tswow-core/Private/TSEventsLua.cpp
@@ -146,6 +146,9 @@ void TSLua::load_events(sol::state& state)
     LUA_HANDLE(unit_events, UnitEvents, OnCalcMissChance);
     LUA_HANDLE(unit_events, UnitEvents, OnCalcHeal);
     LUA_HANDLE(unit_events, UnitEvents, OnMeleeDamageEarly);
+    // @epoch-start
+    LUA_HANDLE(unit_events, UnitEvents, OnMeleeDamage);
+    // @epoch-end
     LUA_HANDLE(unit_events, UnitEvents, OnMeleeDamageLate);
     LUA_HANDLE(unit_events, UnitEvents, OnCalcMeleeCrit);
     LUA_HANDLE(unit_events, UnitEvents, OnCalcMeleeOutcome);
@@ -177,6 +180,9 @@ void TSLua::load_events(sol::state& state)
     LUA_MAPPED_HANDLE(spell_events, SpellEvents, OnRemove);
     LUA_MAPPED_HANDLE(spell_events, SpellEvents, OnApply);
     LUA_MAPPED_HANDLE(spell_events, SpellEvents, OnDamageEarly);
+    // @epoch-start
+    LUA_MAPPED_HANDLE(spell_events, SpellEvents, OnDamage);
+    // @epoch-end
     LUA_MAPPED_HANDLE(spell_events, SpellEvents, OnDamageLate);
     LUA_MAPPED_HANDLE(spell_events, SpellEvents, OnPeriodicDamage);
     LUA_MAPPED_HANDLE(spell_events, SpellEvents, OnCalcMiss);
@@ -219,6 +225,9 @@ void TSLua::load_events(sol::state& state)
     LUA_MAPPED_HANDLE(spell_events, SpellEvents, OnObjectAreaTargetSelect);
     LUA_MAPPED_HANDLE(spell_events, SpellEvents, OnObjectTargetSelect);
     LUA_MAPPED_HANDLE(spell_events, SpellEvents, OnOnResistAbsorbCalculate);
+    /** @epoch-start */
+    LUA_MAPPED_HANDLE(spell_events, SpellEvents, OnHealEarly);
+    /** @epoch-end */
     LUA_MAPPED_HANDLE(spell_events, SpellEvents, OnHealLate);
 
     auto creature_events = state.new_usertype<TSEvents::CreatureEvents>("CreatureEvents");
@@ -273,6 +282,14 @@ void TSLua::load_events(sol::state& state)
     LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnUpdateMaxPower);
     LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnUpdateAttackPowerDamage);
     LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnUpdateDamagePhysical);
+    // @epoch-start
+    LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnUpdateSpellPower);
+    LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnUpdateStamina);
+    LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnUpdateAgility);
+    LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnUpdateStrength);
+    LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnUpdateIntellect);
+    LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnUpdateSpirit);
+    // @epoch-end
     LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnCalcColorCode);
     LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnCalcGain);
     LUA_MAPPED_HANDLE(creature_events, CreatureEvents, OnCalcBaseGain);

--- a/tswow-core/Private/TSUnit.cpp
+++ b/tswow-core/Private/TSUnit.cpp
@@ -2735,4 +2735,18 @@ void TSUnit::MovePath(uint32 path_id, bool repeatable)
 {
     unit->GetMotionMaster()->MovePath(path_id, repeatable);
 }
+
+/**
+ * Adds threat to the [Unit] from the victim.
+ *
+ * @param [Unit] victim : [Unit] that caused the threat
+ * @param float threat : threat amount
+ * @param uint32 spell = 0 : spell entry used for threat
+ */
+void TSUnit::AddThreatAllAssist(TSUnit _victim, TSNumber<float> threat, uint32 spell, bool ignoreModifiers)
+{
+    auto victim = _victim.unit;
+
+    unit->GetThreatManager().ForwardThreatForAssistingMe(victim, threat, sSpellMgr->GetSpellInfo(spell), ignoreModifiers);
+}
 /** @epoch-end */

--- a/tswow-core/Public/TSEvents.h
+++ b/tswow-core/Public/TSEvents.h
@@ -404,6 +404,14 @@ struct TSEvents
             , TSNumber<uint32>
             , TSNumber<uint32>
         )
+        // @epoch-start
+        EVENT(OnMeleeDamage
+            , TSMeleeDamageInfo
+            , TSMutableNumber<uint32>
+            , TSNumber<uint32>
+            , TSNumber<uint32>
+        )
+        // @epoch-end
         EVENT(OnMeleeDamageLate
             , TSMeleeDamageInfo
             , TSMutableNumber<uint32>
@@ -486,6 +494,9 @@ struct TSEvents
         ID_EVENT(OnRemove, TSAuraEffect, TSAuraApplication, TSNumber<uint32>)
         ID_EVENT(OnApply, TSAuraEffect, TSAuraApplication, TSNumber<uint32>)
         ID_EVENT(OnDamageEarly, TSSpell, TSMutableNumber<int32>, TSSpellDamageInfo, TSNumber<uint32>, bool, TSNumber<uint32> effectMask)
+        // @epoch-start
+        ID_EVENT(OnDamage, TSSpell, TSMutableNumber<int32>, TSSpellDamageInfo, TSNumber<uint32>, bool, TSNumber<uint32> effectMask)
+        // @epoch-end
         ID_EVENT(OnDamageLate, TSSpell, TSMutableNumber<uint32>, TSSpellDamageInfo, TSNumber<uint32>, bool, TSNumber<uint32> effectMask)
         ID_EVENT(OnPeriodicDamage, TSAuraEffect, TSMutableNumber<uint32>)
         ID_EVENT(OnCalcSpellPowerLevelPenalty
@@ -532,6 +543,9 @@ struct TSEvents
         ID_EVENT(OnObjectAreaTargetSelect, TSSpell, TSWorldObjectCollection, TSNumber<uint32> index, TSSpellImplicitTargetInfo, TSMutable<bool,bool> cancelDefault)
         ID_EVENT(OnObjectTargetSelect, TSSpell, TSMutableWorldObject, TSNumber<uint32> index, TSSpellImplicitTargetInfo, TSMutable<bool,bool> cancelDefault)
         ID_EVENT(OnOnResistAbsorbCalculate, TSSpell, TSDamageInfo, TSMutableNumber<uint32> resistAmount, TSMutableNumber<int32> absorbAmount, TSMutable<bool,bool> cancelDefault)
+            /** @epoch-start */
+        ID_EVENT(OnHealEarly, TSSpellInfo, TSUnit, TSMutableNumber<uint32>)
+            /** @epoch-end */
         ID_EVENT(OnHealLate, TSSpellInfo, TSUnit, TSUnit, TSNumber<uint32>, bool)
     } Spell;
 
@@ -648,6 +662,38 @@ struct TSEvents
             , bool isGuardian
             , TSNumber<uint8> attType
         )
+        // @epoch-start
+        ID_EVENT(OnUpdateSpellPower
+            , TSCreature
+            , TSMutableNumber<int32>
+            , bool isGuardian
+        )
+        ID_EVENT(OnUpdateStamina
+            , TSCreature
+            , TSMutableNumber<float>
+            , bool isGuardian
+        )
+        ID_EVENT(OnUpdateAgility
+            , TSCreature
+            , TSMutableNumber<float>
+            , bool isGuardian
+        )
+        ID_EVENT(OnUpdateStrength
+            , TSCreature
+            , TSMutableNumber<float>
+            , bool isGuardian
+        )
+        ID_EVENT(OnUpdateIntellect
+            , TSCreature
+            , TSMutableNumber<float>
+            , bool isGuardian
+        )
+        ID_EVENT(OnUpdateSpirit
+            , TSCreature
+            , TSMutableNumber<float>
+            , bool isGuardian
+        )
+        // @epoch-end
         ID_EVENT(OnCalcColorCode
             , TSCreature
             , TSMutableNumber<uint8> code

--- a/tswow-core/Public/TSUnit.h
+++ b/tswow-core/Public/TSUnit.h
@@ -252,6 +252,7 @@ public:
     void StartCooldownExplicit(uint32 spell, uint32 cooldownMs, bool forcePacket);
     void MovePath(uint32 path_id, bool repeatable);
     // uint32 SpellDamageBonusTaken(Unit* caster, SpellInfo const* spellProto, uint32 pdamage, DamageEffectType damagetype);
+    void AddThreatAllAssist(TSUnit victim, TSNumber<float> threat, uint32 spell, bool ignoreModifiers);
     /** @epoch-end*/
 private:
     TSLua::Array<TSUnit> LGetControlled();

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -7486,6 +7486,7 @@ declare interface TSUnit extends TSWorldObject {
     IsPossessedByPlayer(): boolean;
     StartCooldownExplicit(spell: uint32, cooldownMs: uint32, forcePacket: boolean): void;
     MovePath(path_id: uint32, repeatable: boolean): void;
+    AddThreatAllAssist(victim: TSUnit, threat: TSNumber<float>, spell: uint32, ignoreModifiers: bool): void;
     /** @epoch-end */
 }
 
@@ -8274,7 +8275,26 @@ declare namespace _hidden {
           , type: TSNumber<uint32>
           , isCrit: bool
           , effectMask: TSNumber<uint32>
-        )=>void): T
+        ) => void): T
+
+        // @epoch-start
+        OnDamage(callback: (
+            spell: TSSpell
+            , damage: TSMutableNumber<int32>
+            , info: TSSpellDamageInfo
+            , type: TSNumber<uint32>
+            , isCrit: bool
+            , effectMask: TSNumber<uint32>
+        ) => void): T
+        OnDamage(id: EventID, callback: (
+            spell: TSSpell
+            , damage: TSMutableNumber<int32>
+            , info: TSSpellDamageInfo
+            , type: TSNumber<uint32>
+            , isCrit: bool
+            , effectMask: TSNumber<uint32>
+        ) => void): T
+        //@epoch-end
 
         OnDamageLate(callback : (
               spell: TSSpell
@@ -8457,6 +8477,19 @@ declare namespace _hidden {
 
         OnResistAbsorbCalculate(callback: (spelL: TSSpell, damage: TSDamageInfo, resistAmount: TSMutableNumber<uint32>, absorbAmount: TSMutableNumber<int32>, cancel: TSMutable<boolean,boolean> )=>void)
         OnResistAbsorbCalculate(id: EventID, callback: (spelL: TSSpell, damage: TSDamageInfo, resistAmount: TSMutableNumber<uint32>, absorbAmount: TSMutableNumber<int32>, cancel: TSMutable<boolean,boolean> )=>void)
+        
+        /** @epoch-start */
+        OnHealEarly(callback : (
+            spell: TSSpellInfo
+            , target: TSUnit
+            , amount: TSMutableNumber<uint32>
+        )=>void): T
+        OnHealEarly(id: EventID, callback : (
+            spell: TSSpellInfo
+            , target: TSUnit
+            , amount: TSMutableNumber<uint32>
+        )=>void): T
+        /** @epoch-end */
 
         OnHealLate(callback : (
             spell: TSSpellInfo
@@ -8671,6 +8704,68 @@ declare namespace _hidden {
             , isGuardian: bool
             , attType: WeaponAttackType
         )=>void)
+        // @epoch-start
+        OnUpdateSpellPower(callback: (
+              creature: TSCreature
+            , value: TSMutableNumber<int32>
+            , isGuardian: bool
+        ) => void)
+        OnUpdateSpellPower(id: EventID, callback: (
+              creature: TSCreature
+            , value: TSMutableNumber<int32>
+            , isGuardian: bool
+        ) => void)
+        OnUpdateStamina(callback: (
+            creature: TSCreature
+            , value: TSMutableNumber<float>
+            , isGuardian: bool
+        ) => void)
+        OnUpdateStamina(id: EventID, callback: (
+            creature: TSCreature
+            , value: TSMutableNumber<float>
+            , isGuardian: bool
+        ) => void)
+        OnUpdateAgility(callback: (
+            creature: TSCreature
+            , value: TSMutableNumber<float>
+            , isGuardian: bool
+        ) => void)
+        OnUpdateAgility(id: EventID, callback: (
+            creature: TSCreature
+            , value: TSMutableNumber<float>
+            , isGuardian: bool
+        ) => void)
+        OnUpdateStrength(callback: (
+            creature: TSCreature
+            , value: TSMutableNumber<float>
+            , isGuardian: bool
+        ) => void)
+        OnUpdateStrength(id: EventID, callback: (
+            creature: TSCreature
+            , value: TSMutableNumber<float>
+            , isGuardian: bool
+        ) => void)
+        OnUpdateIntellect(callback: (
+            creature: TSCreature
+            , value: TSMutableNumber<float>
+            , isGuardian: bool
+        ) => void)
+        OnUpdateIntellect(id: EventID, callback: (
+            creature: TSCreature
+            , value: TSMutableNumber<float>
+            , isGuardian: bool
+        ) => void)
+        OnUpdateSpirit(callback: (
+            creature: TSCreature
+            , value: TSMutableNumber<float>
+            , isGuardian: bool
+        ) => void)
+        OnUpdateSpirit(id: EventID, callback: (
+            creature: TSCreature
+            , value: TSMutableNumber<float>
+            , isGuardian: bool
+        ) => void)
+        // @epoch-end
 
         OnUpdateLvlDepMaxHealth(callback: (
             creature: TSCreature
@@ -8868,6 +8963,14 @@ declare namespace _hidden {
             , index: TSNumber<uint32>
             )=>void
         )
+        // @epoch-start
+        OnMeleeDamage(callback: (
+            info: TSMeleeDamageInfo
+            , damage: TSMutableNumber<uint32>
+            , type: TSNumber<uint32>
+            , index: TSNumber<uint32>
+        ) => void)
+        // @epoch-end
         OnMeleeDamageLate(callback: (
               info: TSMeleeDamageInfo
             , damage: TSMutableNumber<uint32>


### PR DESCRIPTION
Adds TSWoW functions for:
OnHealEarly (used to change the amount dealt by a healing spell)

OnDamage/OnDamageMelee (fits between OnDamageEarly and OnDamageLate, after its calculated but before its applied, needed for Cheat Death)

Creature OnUpdateSpellPower and every other stat (runs after pet stats are calculated, allows replacing the stat with our own formula)

AddThreatAllAssist (generates threat to everything on the aggro table, using the same functions used by healing spells. Does not work currently)