### PR TITLE
WorldObjectCollection Index

### DIFF
--- a/tswow-core/Private/TSWorldObject.cpp
+++ b/tswow-core/Private/TSWorldObject.cpp
@@ -1299,21 +1299,25 @@ void TSMutableWorldObject::set(TSWorldObject value)
 
 TS_CLASS_DEFINITION(TSWorldObjectCollection, std::list<WorldObject*>, m_info)
 
-void TSWorldObjectCollection::filterInPlace(std::function<bool(TSWorldObject)> callback)
+// @epoch-start
+void TSWorldObjectCollection::filterInPlace(std::function<bool(TSWorldObject, size_t)> callback)
 {
     auto itr = m_info->begin();
+    size_t index = 0;
     while (itr != m_info->end())
     {
-        if (!callback(TSWorldObject(*itr)))
+        if (!callback(TSWorldObject(*itr), index))
         {
             itr = m_info->erase(itr);
         }
         else
         {
+            ++index;
             itr++;
         }
     }
 }
+// @epoch-end
 
 TSNumber<uint32> TSWorldObjectCollection::get_length()
 {
@@ -1327,25 +1331,33 @@ TSWorldObject TSWorldObjectCollection::get(uint32 index)
     return TSWorldObject(*front);
 }
 
-void TSWorldObjectCollection::forEach(std::function<void(TSWorldObject)> callback)
+// @epoch-start
+void TSWorldObjectCollection::forEach(std::function<void(TSWorldObject, size_t)> callback)
 {
+    size_t index = 0;
+
     for (WorldObject* obj : *m_info)
     {
-        callback(TSWorldObject(obj));
+        callback(TSWorldObject(obj), index);
+        ++index;
     }
 }
 
-TSWorldObject TSWorldObjectCollection::find(std::function<bool(TSWorldObject)> callback)
+TSWorldObject TSWorldObjectCollection::find(std::function<bool(TSWorldObject, size_t)> callback)
 {
+    size_t index = 0;
+
     for (WorldObject* obj : *m_info)
     {
-        if (callback(obj))
+        if (callback(obj, index))
         {
             return TSWorldObject(obj);
+                ++index;
         }
     }
     return TSWorldObject(nullptr);
 }
+// @epoch-end
 
 
 TSFactionTemplate TSWorldObject::GetFactionTemplate()

--- a/tswow-core/Public/TSWorldObject.h
+++ b/tswow-core/Public/TSWorldObject.h
@@ -221,9 +221,11 @@ class TC_GAME_API TSMutableWorldObject
 class TC_GAME_API TSWorldObjectCollection
 {
     TS_CLASS_DECLARATION(TSWorldObjectCollection, std::list<WorldObject*>, m_info)
-    void filterInPlace(std::function<bool(TSWorldObject)> callback);
-    void forEach(std::function<void(TSWorldObject)> callback);
-    TSWorldObject find(std::function<bool(TSWorldObject)> callback);
+    // @epoch-start
+    void filterInPlace(std::function<bool(TSWorldObject, size_t)> callback);
+    void forEach(std::function<void(TSWorldObject, size_t)> callback);
+    TSWorldObject find(std::function<bool(TSWorldObject, size_t)> callback);
+    // @epoch-end
     TSNumber<uint32> get_length();
     TSWorldObject get(uint32 index);
 };

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -5761,9 +5761,11 @@ declare interface TSWorldObject extends TSObject, TSWorldEntityProvider<TSWorldO
 }
 
 declare interface TSWorldObjectCollection {
-    filterInPlace(callback: (obj: TSWorldObject)=>bool): void
-    forEach(callback: (obj: TSWorldObject)=>void) :void
-    find(callback: (obj: TSWorldObject)=>bool): TSWorldObject
+    // @epoch-start
+    filterInPlace(callback: (obj: TSWorldObject, index: uint16)=>bool): void
+    forEach(callback: (obj: TSWorldObject, index: uint16)=>void) :void
+    find(callback: (obj: TSWorldObject, index: uint16) => bool): TSWorldObject
+    // @epoch-end
     length: TSNumber<uint32>
     /**
      * @warn This is an O(n) operation, because the backing type is an std::list


### PR DESCRIPTION
Implements an index option in World Object Collection so that livescripts using things that use it such as OnObjectAreaTargetSelect can utilize the index of the array. Needed for smart healing for Healing Stream Totem.