### PR TITLE
Add Loot Condition Cloning

### DIFF
--- a/tswow-scripts/wotlk/sql/creature_loot_template.ts
+++ b/tswow-scripts/wotlk/sql/creature_loot_template.ts
@@ -84,6 +84,11 @@ export class creature_loot_templateRow extends SqlRow<creature_loot_templateCrea
     get Comment() {return new SQLCell<varchar, this>(this, 'Comment')}
 
     /**
+     * No comment (yet!)
+     */
+    get Table(): string { return this.table.name }
+
+    /**
      * Creates a clone of this row with new primary keys.
      *
      * Cloned rows are automatically added to the SQL table.

--- a/tswow-scripts/wotlk/sql/disenchant_loot_template.ts
+++ b/tswow-scripts/wotlk/sql/disenchant_loot_template.ts
@@ -84,6 +84,11 @@ export class disenchant_loot_templateRow extends SqlRow<disenchant_loot_template
     get Comment() {return new SQLCell<varchar, this>(this, 'Comment')}
 
     /**
+     * No comment (yet!)
+     */
+    get Table(): string { return this.table.name }
+
+    /**
      * Creates a clone of this row with new primary keys.
      *
      * Cloned rows are automatically added to the SQL table.

--- a/tswow-scripts/wotlk/sql/fishing_loot_template.ts
+++ b/tswow-scripts/wotlk/sql/fishing_loot_template.ts
@@ -84,6 +84,11 @@ export class fishing_loot_templateRow extends SqlRow<fishing_loot_templateCreato
     get Comment() {return new SQLCell<varchar, this>(this, 'Comment')}
 
     /**
+     * No comment (yet!)
+     */
+    get Table(): string { return this.table.name }
+
+    /**
      * Creates a clone of this row with new primary keys.
      *
      * Cloned rows are automatically added to the SQL table.

--- a/tswow-scripts/wotlk/sql/gameobject_loot_template.ts
+++ b/tswow-scripts/wotlk/sql/gameobject_loot_template.ts
@@ -84,6 +84,11 @@ export class gameobject_loot_templateRow extends SqlRow<gameobject_loot_template
     get Comment() {return new SQLCell<varchar, this>(this, 'Comment')}
 
     /**
+     * No comment (yet!)
+     */
+    get Table(): string { return this.table.name }
+
+    /**
      * Creates a clone of this row with new primary keys.
      *
      * Cloned rows are automatically added to the SQL table.

--- a/tswow-scripts/wotlk/sql/item_loot_template.ts
+++ b/tswow-scripts/wotlk/sql/item_loot_template.ts
@@ -84,6 +84,11 @@ export class item_loot_templateRow extends SqlRow<item_loot_templateCreator,item
     get Comment() {return new SQLCell<varchar, this>(this, 'Comment')}
 
     /**
+     * No comment (yet!)
+     */
+    get Table(): string { return this.table.name }
+
+    /**
      * Creates a clone of this row with new primary keys.
      *
      * Cloned rows are automatically added to the SQL table.

--- a/tswow-scripts/wotlk/sql/mail_loot_template.ts
+++ b/tswow-scripts/wotlk/sql/mail_loot_template.ts
@@ -84,6 +84,11 @@ export class mail_loot_templateRow extends SqlRow<mail_loot_templateCreator,mail
     get Comment() {return new SQLCell<varchar, this>(this, 'Comment')}
 
     /**
+     * No comment (yet!)
+     */
+    get Table(): string { return this.table.name }
+
+    /**
      * Creates a clone of this row with new primary keys.
      *
      * Cloned rows are automatically added to the SQL table.

--- a/tswow-scripts/wotlk/sql/milling_loot_template.ts
+++ b/tswow-scripts/wotlk/sql/milling_loot_template.ts
@@ -84,6 +84,11 @@ export class milling_loot_templateRow extends SqlRow<milling_loot_templateCreato
     get Comment() {return new SQLCell<varchar, this>(this, 'Comment')}
 
     /**
+     * No comment (yet!)
+     */
+    get Table(): string { return this.table.name }
+
+    /**
      * Creates a clone of this row with new primary keys.
      *
      * Cloned rows are automatically added to the SQL table.

--- a/tswow-scripts/wotlk/sql/pickpocketing_loot_template.ts
+++ b/tswow-scripts/wotlk/sql/pickpocketing_loot_template.ts
@@ -84,6 +84,11 @@ export class pickpocketing_loot_templateRow extends SqlRow<pickpocketing_loot_te
     get Comment() {return new SQLCell<varchar, this>(this, 'Comment')}
 
     /**
+     * No comment (yet!)
+     */
+    get Table(): string { return this.table.name }
+
+    /**
      * Creates a clone of this row with new primary keys.
      *
      * Cloned rows are automatically added to the SQL table.

--- a/tswow-scripts/wotlk/sql/prospecting_loot_template.ts
+++ b/tswow-scripts/wotlk/sql/prospecting_loot_template.ts
@@ -84,6 +84,11 @@ export class prospecting_loot_templateRow extends SqlRow<prospecting_loot_templa
     get Comment() {return new SQLCell<varchar, this>(this, 'Comment')}
 
     /**
+     * No comment (yet!)
+     */
+    get Table(): string { return this.table.name }
+
+    /**
      * Creates a clone of this row with new primary keys.
      *
      * Cloned rows are automatically added to the SQL table.

--- a/tswow-scripts/wotlk/sql/reference_loot_template.ts
+++ b/tswow-scripts/wotlk/sql/reference_loot_template.ts
@@ -84,6 +84,11 @@ export class reference_loot_templateRow extends SqlRow<reference_loot_templateCr
     get Comment() {return new SQLCell<varchar, this>(this, 'Comment')}
 
     /**
+     * No comment (yet!)
+     */
+    get Table(): string { return this.table.name }
+
+    /**
      * Creates a clone of this row with new primary keys.
      *
      * Cloned rows are automatically added to the SQL table.

--- a/tswow-scripts/wotlk/sql/skinning_loot_template.ts
+++ b/tswow-scripts/wotlk/sql/skinning_loot_template.ts
@@ -84,6 +84,11 @@ export class skinning_loot_templateRow extends SqlRow<skinning_loot_templateCrea
     get Comment() {return new SQLCell<varchar, this>(this, 'Comment')}
 
     /**
+     * No comment (yet!)
+     */
+    get Table(): string { return this.table.name }
+
+    /**
      * Creates a clone of this row with new primary keys.
      *
      * Cloned rows are automatically added to the SQL table.

--- a/tswow-scripts/wotlk/sql/spell_loot_template.ts
+++ b/tswow-scripts/wotlk/sql/spell_loot_template.ts
@@ -84,6 +84,11 @@ export class spell_loot_templateRow extends SqlRow<spell_loot_templateCreator,sp
     get Comment() {return new SQLCell<varchar, this>(this, 'Comment')}
 
     /**
+     * No comment (yet!)
+     */
+    get Table(): string { return this.table.name }
+
+    /**
      * Creates a clone of this row with new primary keys.
      *
      * Cloned rows are automatically added to the SQL table.

--- a/tswow-scripts/wotlk/std/Loot/Loot.ts
+++ b/tswow-scripts/wotlk/std/Loot/Loot.ts
@@ -34,6 +34,7 @@ export interface LootRowBase {
     MaxCount: SQLCell<number,any>;
     clone(id: number, item: number): any;
     Table: string;
+    delete(): void;
 }
 
 export interface LootTable {

--- a/tswow-scripts/wotlk/std/Loot/Loot.ts
+++ b/tswow-scripts/wotlk/std/Loot/Loot.ts
@@ -33,6 +33,7 @@ export interface LootRowBase {
     MinCount: SQLCell<number,any>;
     MaxCount: SQLCell<number,any>;
     clone(id: number, item: number): any;
+    Table: string;
 }
 
 export interface LootTable {
@@ -169,19 +170,61 @@ export class LootSetPointer<T> extends CellWrapper<number,T>{
         return this.owner;
     }
 
-    getRefCopy() {
+    getRefCopy(conditions: bool = true) {
         let old = this.cell.get();
         let nu = this.gen.id();
         this.cell.set(nu);
         this.table.queryAll({Entry:old}).forEach(x=>{
             x.clone(nu,x.Item.get())
-                .Comment.set('tswow')
+                .Comment.set('tswow');
+
+            /** Clone Conditions. */
+            if (conditions) {
+                let source = 0;
+
+                switch (x.Table) {
+                    case 'creature_loot_template': source = 1; break;
+                    case 'disenchant_loot_template': source = 2; break;
+                    case 'fishing_loot_template': source = 3; break;
+                    case 'gameobject_loot_template': source = 4; break;
+                    case 'item_loot_template': source = 5; break;
+                    case 'mail_loot_template': source = 6; break;
+                    case 'milling_loot_template': source = 7; break;
+                    case 'pickpocketing_loot_template': source = 8; break;
+                    case 'prospecting_loot_template': source = 9; break;
+                    case 'reference_loot_template': source = 10; break;
+                    case 'skinning_loot_template': source = 11; break;
+                    case 'spell_loot_template': source = 12; break;
+                }
+
+                if (source === 0)
+                    return;
+
+                SQL.conditions.queryAll({
+                    SourceTypeOrReferenceId: source,
+                    SourceGroup: old,
+                    SourceEntry: x.Item.get(),
+                }).forEach((cond) => {
+                    cond.clone(
+                        source,
+                        nu,
+                        cond.SourceEntry.get(),
+                        cond.SourceId.get(),
+                        cond.ElseGroup.get(),
+                        cond.ConditionTypeOrReference.get(),
+                        cond.ConditionTarget.get(),
+                        cond.ConditionValue1.get(),
+                        cond.ConditionValue2.get(),
+                        cond.ConditionValue3.get()
+                    );
+                });
+            }
         })
         return this.getRef();
     }
 
-    modRefCopy(callback: (table: LootSet)=>void) {
-        callback(this.getRefCopy());
+    modRefCopy(callback: (table: LootSet)=>void, conditions: bool = true) {
+        callback(this.getRefCopy(conditions));
         return this.owner;
     }
 }


### PR DESCRIPTION
When a loot table is cloned via `modRefCopy` or `getRefCopy` we now also clone the conditions for any loot on the table. Not doing so causes items to drop unexpectedly. This can be opted out but the default is now to clone.