### PR TITLE
Item vendor price improvements

### DIFF
--- a/tswow-scripts/wotlk/std/Item/ItemPrice.ts
+++ b/tswow-scripts/wotlk/std/Item/ItemPrice.ts
@@ -38,28 +38,47 @@ export class ItemPrice extends CellSystem<ItemTemplate> {
         return new MoneyCell(this.owner,'COPPER', this.owner.row.SellPrice);
     }
 
+    /**
+     * @param sellPrice Setting this to "-1" will automatically set the sell price to 1/4th the buy price.
+     */
     set(sellPrice: number, buyPrice: number, buyCount: number = 1, currency: CoinType = 'COPPER') {
-        if(sellPrice>buyPrice) {
+        if(sellPrice > buyPrice) {
             throw new Error(`Tried to set an item price where sellPrice > buyPrice, this will lead to exploits. Use setUnsafe if you really must.`)
         }
+        else if(sellPrice > (buyPrice * 0.8) && buyPrice != 0 && sellPrice != 0 && buyPrice != 1 && sellPrice != 1) {
+            throw new Error(`Tried to set an item price where sellPrice > buyPrice with maximum discount (20%), this will lead to exploits. Use setUnsafe if you really must.`)
+        }
+        const sell = sellPrice === -1 ? buyPrice / 4 : sellPrice
         return this.setUnsafe(
-              sellPrice
+              sell
             , buyPrice
             , buyCount
             , currency
         );
     }
 
+    /**
+     * @param sellPrice Setting this to "-1" will automatically set the sell price to 1/4th the buy price.
+     */
     setAsCopper(sellPrice: number, buyPrice: number, buyCount: number = 1) {
-        return this.set(sellPrice,buyPrice,buyCount,'COPPER')
+        const sell = sellPrice === -1 ? buyPrice / 4 : sellPrice
+        return this.set(sell,buyPrice,buyCount,'COPPER')
     }
 
+    /**
+     * @param sellPrice Setting this to "-1" will automatically set the sell price to 1/4th the buy price.
+     */
     setAsSilver(sellPrice: number, buyPrice: number, buyCount: number = 1) {
-        return this.set(sellPrice,buyPrice,buyCount,'SILVER')
+        const sell = sellPrice === -1 ? buyPrice / 4 : sellPrice
+        return this.set(sell,buyPrice,buyCount,'SILVER')
     }
 
+    /**
+     * @param sellPrice Setting this to "-1" will automatically set the sell price to 1/4th the buy price.
+     */
     setAsGold(sellPrice: number, buyPrice: number, buyCount: number = 1) {
-        return this.set(sellPrice,buyPrice,buyCount,'GOLD')
+        const sell = sellPrice === -1 ? buyPrice / 4 : sellPrice
+        return this.set(sell,buyPrice,buyCount,'GOLD')
     }
 
     setUnsafe(sellPrice: number, buyPrice: number, buyCount: number = 1, currency: CoinType = 'COPPER')  {


### PR DESCRIPTION
Item vendor prices now accept "-1" as a valid sell price, which automatically sets the sell price to be 1/4th the buy price.

Added new error to item sell price if the item would cause a gold exploit using reputation discounts by being sold for more than 80% of the item's buy price.