### PR TITLE
Dataset SQL Overrides

### DIFF
--- a/tswow-scripts/runtime/Dataset.ts
+++ b/tswow-scripts/runtime/Dataset.ts
@@ -162,7 +162,12 @@ export class Dataset {
 
         switch(this.config.EmulatorCore) {
             case 'trinitycore':
-                await mysql.applySQLFiles(db,'world');
+                await mysql.applySQLUpdates(db,'world');
+
+                if (this.path.sql_updates.world.exists()) {
+                    await mysql.applyExtraSQLUpdates(db, this.path.sql_updates.world);
+                }
+                
                 break;
             case 'azerothcore':
                 // todo: updates

--- a/tswow-scripts/runtime/MySQL.ts
+++ b/tswow-scripts/runtime/MySQL.ts
@@ -392,7 +392,10 @@ export namespace mysql {
         return total;
     }
 
-    export async function applySQLFiles(
+    /**
+     * Applies updates that came from core in bin/sql.
+     */
+    export async function applySQLUpdates(
           cons: Connection
         , type: 'world'|'auth'|'characters'
     ) {
@@ -400,6 +403,18 @@ export namespace mysql {
         total += await makeUpdate(cons, ipaths.bin.sql.custom.type.pick(type).toDirectory())
         if(total > 0) {
             term.success('mysql',`Applied ${total} updates for ${cons.name()}`)
+        }
+    }
+
+    /**
+     * Apply sql file based mods that should run once on rebuild.
+     * Useful for large data migrations / edits. Limited to world
+     * for now.
+     */
+    export async function applyExtraSQLUpdates(cons: Connection, path: WDirectory) {
+        let total = await makeUpdate(cons, path.toDirectory());
+        if(total > 0) {
+            term.success('mysql',`Applied ${total} mods for ${cons.name()}`)
         }
     }
 
@@ -429,7 +444,7 @@ export namespace mysql {
 
         switch(core) {
             case 'trinitycore':
-                await applySQLFiles(connection,'characters');
+                await applySQLUpdates(connection,'characters');
                 break;
             case 'azerothcore':
                 // TODO: currently does not apply updates, this is wrong of course.
@@ -447,7 +462,7 @@ export namespace mysql {
 
             await connection.query(wfs.read(ipaths.bin.sql.auth_create_sql.get()));
         }
-        await applySQLFiles(connection,'auth');
+        await applySQLUpdates(connection,'auth');
     }
 
     export async function initialize() {

--- a/tswow-scripts/util/Paths.ts
+++ b/tswow-scripts/util/Paths.ts
@@ -78,7 +78,10 @@ export function DatasetDirectory(inPath: string, inName: string) {
         config: file(`dataset.conf`),
         ids_txt: file('ids.txt'),
         modules_txt: file('modules.txt'),
-        world_sql: file('world.sql')
+        world_sql: file('world.sql'),
+        sql_updates: dir({
+            world: dir({}),
+        }),
     }))
 }
 


### PR DESCRIPTION
Adds a folder within the `dataset` directory where you can store sql files that will be applied to the source and dest db. This is an upfront build time that then makes subsequent `build data` runs faster. 

This is particularly helpful for large data migrations that you want to mod on top of such as Epoch restoring creature levels, item stats, loot tables, etc.