### PR TITLE
Item price fix when buycount is above 1

### DIFF
--- a/tswow-scripts/wotlk/std/Item/ItemPrice.ts
+++ b/tswow-scripts/wotlk/std/Item/ItemPrice.ts
@@ -51,7 +51,7 @@ export class ItemPrice extends CellSystem<ItemTemplate> {
         const sell = sellPrice === -1 ? buyPrice / 4 : sellPrice
         return this.setUnsafe(
               sell
-            , buyPrice
+            , buyPrice * buyCount // Multiply buyprice by buycount so buyprice still equates to the cost of 1 item
             , buyCount
             , currency
         );


### PR DESCRIPTION
BuyPrice is now multiplied by BuyCount to avoid gold duplication by making set price more sensible.

Before this, buyprice denoted the cost of the whole stack, while sellprice was the cost of 1 item of the stack. This was not very clear and caused mistakes that would surely be made again.