### PR TITLE
GetCharges() and SetCharges() for TSAura

### DIFF
--- a/tswow-core/Private/TSAura.cpp
+++ b/tswow-core/Private/TSAura.cpp
@@ -297,6 +297,18 @@ TSNumber<uint32> TSAura::GetStackAmount()
     return aura->GetStackAmount();
 }
 
+/** @epoch-start */
+/**
+ * Returns the number of charges remaining on the aura.
+ *
+ * @return uint32 charges
+ */
+TSNumber<uint32> TSAura::GetCharges()
+{
+    return aura->GetCharges();
+}
+/** @epoch-end */
+
 /**
  * Returns the [Unit] that the [Aura] has been applied to.
  *
@@ -368,6 +380,18 @@ void TSAura::SetStackAmount(uint8 amount)
     aura->GetHolder()->SetStackAmount(amount);
 #endif
 }
+
+/** @epoch-start */
+/**
+ * Change the amount of remaining charges the [Aura] has on the [Unit].
+ *
+ * @param uint32 amount
+ */
+void TSAura::SetCharges(uint8 amount)
+{
+    aura->SetCharges(amount);
+}
+/** @epoch-end */
 
 /**
  * Remove this [Aura] from the [Unit] it is applied to.

--- a/tswow-core/Private/TSAuraLua.cpp
+++ b/tswow-core/Private/TSAuraLua.cpp
@@ -45,10 +45,16 @@ void TSLua::load_aura_methods(sol::state& state)
     LUA_FIELD(ts_aura, TSAura, GetAuraID);
     LUA_FIELD(ts_aura, TSAura, GetMaxDuration);
     LUA_FIELD(ts_aura, TSAura, GetStackAmount);
+    /** @epoch-start */
+    LUA_FIELD(ts_aura, TSAura, GetCharges);
+    /** @epoch-end */
     LUA_FIELD(ts_aura, TSAura, GetOwner);
     LUA_FIELD(ts_aura, TSAura, SetDuration);
     LUA_FIELD(ts_aura, TSAura, SetMaxDuration);
     LUA_FIELD(ts_aura, TSAura, SetStackAmount);
+    /** @epoch-start */
+    LUA_FIELD(ts_aura, TSAura, SetCharges);
+    /** @epoch-end */
     LUA_FIELD(ts_aura, TSAura, Remove);
     LUA_FIELD(ts_aura, TSAura, GetEffect);
     ts_aura.set_function("GetApplications", &TSAura::LGetApplications);

--- a/tswow-core/Public/TSAura.h
+++ b/tswow-core/Public/TSAura.h
@@ -87,12 +87,18 @@ public:
     TSNumber<uint32> GetAuraID();
     TSNumber<int32> GetMaxDuration();
     TSNumber<uint32> GetStackAmount();
+    /** @epoch-start */
+    TSNumber<uint32> GetCharges();
+    /** @epoch-end */
     TSWorldObject GetOwner();
     TSAuraEffect GetEffect(uint8 index);
     TSArray<TSAuraApplication> GetApplications();
     void SetDuration(int32 duration);
     void SetMaxDuration(int32 duration);
     void SetStackAmount(uint8 amount);
+    /** @epoch-start */
+    void SetCharges(uint8 amount);
+    /** @epoch-end */
     void Remove();
     void RefreshDuration(bool withMods);
 private:

--- a/tswow-core/Public/global.d.ts
+++ b/tswow-core/Public/global.d.ts
@@ -3393,7 +3393,16 @@ declare interface TSAura extends TSEntityProvider {
      *
      * @return uint32 stack_amount
      */
-    GetStackAmount() : TSNumber<uint32>
+    GetStackAmount(): TSNumber<uint32>
+
+    /** @epoch-start */
+    /**
+     * Returns the number of charges remaining on the aura.
+     *
+     * @return uint32 charges
+     */
+    GetCharges(): TSNumber<uint32>
+    /** @epoch-end */
 
     /**
      * Returns the [Unit] that the [Aura] has been applied to.
@@ -3433,7 +3442,16 @@ declare interface TSAura extends TSEntityProvider {
      *
      * @param uint32 amount
      */
-    SetStackAmount(amount : uint8) : void
+    SetStackAmount(amount: uint8): void
+
+    /** @epoch-start */
+    /**
+     * Change the amount of remaining charges the [Aura] has on the [Unit].
+     *
+     * @param uint32 amount
+     */
+    SetCharges(amount: uint8): void
+    /** @epoch-end */
 
     /**
      * Remove this [Aura] from the [Unit] it is applied to.


### PR DESCRIPTION
Added GetCharges and SetCharges for auras, this is different than the stackamount, though they look identical in game. Lightning Shield is an example of a spell that uses charges *not* stacks.