### PR TITLE
shell fixes

### DIFF
--- a/tswow-scripts/compile/TrinityCore.ts
+++ b/tswow-scripts/compile/TrinityCore.ts
@@ -218,6 +218,7 @@ export namespace TrinityCore {
     }
 
     export async function install(cmake: string, openssl: string, mysql: string, args1: string[]) {
+        bpaths.TrinityCore.mkdir();
         spaths.build_conf.copy(ipaths.bin.build_conf)
         term.log('build','Building TrinityCore');
         const buildTypes = parseBuildTypes(spaths.build_conf).filter(x => args1.includes(x.Name))

--- a/tswow-scripts/runtime/AuthServer.ts
+++ b/tswow-scripts/runtime/AuthServer.ts
@@ -99,7 +99,7 @@ export namespace AuthServer {
             ,'debug|release?'
             ,'Starts the local authserver'
             , (args)=>{
-            return start(Identifier.getBuildType(args).Name);
+            return start(Identifier.getBuildType(args, NodeConfig.DefaultBuildType).Name);
         }).addAlias('auth');
     }
 }

--- a/tswow-scripts/runtime/Realm.ts
+++ b/tswow-scripts/runtime/Realm.ts
@@ -449,6 +449,7 @@ export class Realm {
             try {
                 wsys.exec(`echo "core" | sudo tee /proc/sys/kernel/core_pattern`)
             } catch(e) {
+                term.error(this.logName(), `Failed to set core pattern, core dumps could not work`)
             }
             wsys.exec(`export ASAN_OPTIONS=${NodeConfig.AsanOptions}`)
         }

--- a/tswow-scripts/runtime/Realm.ts
+++ b/tswow-scripts/runtime/Realm.ts
@@ -445,6 +445,11 @@ export class Realm {
 
         if (!isWindows()) {
             wsys.exec(`ulimit -c ${NodeConfig.CoreDumpSize}`)
+            // todo: should check what core is instead
+            try {
+                wsys.exec(`echo "core" | sudo tee /proc/sys/kernel/core_pattern`)
+            } catch(e) {
+            }
             wsys.exec(`export ASAN_OPTIONS=${NodeConfig.AsanOptions}`)
         }
 

--- a/tswow-scripts/runtime/Realm.ts
+++ b/tswow-scripts/runtime/Realm.ts
@@ -237,10 +237,11 @@ export class Realm {
                     // removed so that next crash doesn't accidentally use the last core dump
                     corePath.remove()
 
-                    this.path.readDir().filter(x => x.startsWith(`core-`)).sort().slice(NodeConfig.CoresKept)
+                    this.path.readDir('ABSOLUTE').filter(x => x.basename().startsWith(`core-`)).sort().slice(NodeConfig.CoresKept)
                         .forEach(x => x.remove())
 
-                    this.path.readDir().filter(x => x.startsWith(`stacktrace-`)).sort().slice(NodeConfig.StackTracesKept)
+                    this.path.readDir('ABSOLUTE').filter(x => x.basename().startsWith(`stacktrace-`)).sort().slice(NodeConfig.StackTracesKept)
+                        .forEach(x => x.remove())
                 } else {
                     term.log(this.logName(), `No core was found`)
                 }
@@ -259,11 +260,13 @@ export class Realm {
                 const copyPath = this.path.join(`${filename}-${dateStr}.log`)
                 x.copy(copyPath)
             })
-            this.path.readDir().filter(x => x.startsWith(`Server-`) && x.endsWith(`.log`)).sort().slice(NodeConfig.LogsKept)
+            this.path.readDir('ABSOLUTE').filter(x => x.basename().startsWith(`Server-`) && x.endsWith(`.log`)).sort().slice(NodeConfig.LogsKept)
                 .forEach(x => x.remove())
-            this.path.readDir().filter(x => x.startsWith(`GM-`) && x.endsWith(`.log`)).sort().slice(NodeConfig.LogsKept)
+            this.path.readDir('ABSOLUTE').filter(x => x.basename().startsWith(`GM-`) && x.endsWith(`.log`)).sort().slice(NodeConfig.LogsKept)
                 .forEach(x => x.remove())
-            this.path.readDir().filter(x => x.startsWith(`DBErrors-`) && x.endsWith(`.log`)).sort().slice(NodeConfig.LogsKept)
+            this.path.readDir('ABSOLUTE').filter(x => x.basename().startsWith(`DBErrors-`) && x.endsWith(`.log`)).sort().slice(NodeConfig.LogsKept)
+                .forEach(x => x.remove())
+            this.path.readDir('ABSOLUTE').filter(x => x.basename().startsWith(`anticheat_`) && x.endsWith(`.log`)).sort().slice(NodeConfig.LogsKept)
                 .forEach(x => x.remove())
         })
 

--- a/tswow-scripts/util/Paths.ts
+++ b/tswow-scripts/util/Paths.ts
@@ -28,11 +28,15 @@ export const DATASET_CLIENT_PATCH_LETTER = 'Client.Patch.Letter'
 
 function currentCommitShort()
 {
-    return child_process
-        .execSync('git rev-parse --short HEAD')
-        .toString('utf-8')
-        .trimRight()
-        .trimLeft()
+    try {
+        return child_process
+            .execSync('git rev-parse --short HEAD')
+            .toString('utf-8')
+            .trimRight()
+            .trimLeft()
+    } catch(e) {
+        return 'unknown';
+    }
 }
 
 export function tdbFilename() {

--- a/tswow-scripts/util/Process.ts
+++ b/tswow-scripts/util/Process.ts
@@ -50,7 +50,7 @@ if(!isWindows())
         cleanup()
     });
     process.on('uncaughtException', (a) => {
-        term.error('process', `shell uncaught exception: ${a}`)
+        term.error('process', `shell uncaught exception: ${a.message}${a.stack ? `\n${a.stack}` : ``}`)
         cleanup()
         process.exit(1)
     });

--- a/tswow-scripts/util/Process.ts
+++ b/tswow-scripts/util/Process.ts
@@ -234,8 +234,7 @@ export class Process {
         , force: boolean = false
     ) {
         term.debug('process', `stopping`)
-        // todo: don't always force
-        if (force || true) {
+        if (force) {
             try {
                 this._process.kill(9);
                 await new Promise(res=>setTimeout(res,1000));


### PR DESCRIPTION
This should clean up the worst mess from the shell hackfixes and fix issues with broken logs and missing core dumps.

The issue causing core dumps not to appear was likely that the old internal debian script changed core dumps names, so the shell script didn't detect them. Currently, it forces core dumps to use the name "core", but a slightly improved approach can be to use the existing pattern instead.

Apologies for the mess.